### PR TITLE
Jfusion2.0 url parse fix

### DIFF
--- a/components/com_jfusion/plugins/phpbb31/public.php
+++ b/components/com_jfusion/plugins/phpbb31/public.php
@@ -426,10 +426,6 @@ class JFusionPublic_phpbb31 extends JFusionPublic
             $regex_body[] = '#action="(.*?)"(.*?)>#m';
             $replace_body[] = ''; //$this->fixAction('$1', '$2', "' . $data->baseURL . '")';
             $callback_function[] = 'fixAction';   
-            //convert relative popup links to full url links
-            $regex_body[] = '#popup\(\'[\.\/].*?(.*?)\'#mS';
-            $replace_body[] = 'popup(\'' . $data->integratedURL . '$1\'';
-            $callback_function[] = '';    
             //fix for mcp links
 	        $mainframe = JFusionFactory::getApplication();
             $jfile = $mainframe->input->get('jfile');
@@ -728,14 +724,6 @@ class JFusionPublic_phpbb31 extends JFusionPublic
             $regex_header[] = '#<meta http-equiv="refresh" content="(.*?)"(.*?)>#m';
             $replace_header[] = '';
             $callback_header[] = 'fixRedirect';
-            //fix pm popup URL to be absolute for some phpBB templates
-            $regex_header[] = '#var url = \'[\.\/].*?(.*?)\';#mS';
-            $replace_header[] = 'var url = \'{$data->integratedURL}$1\';';
-            $callback_header[] = '';
-            //convert relative popup links to full url links
-            $regex_header[] = '#popup\(\'[\.\/].*?(.*?)\'#mS';
-            $replace_header[] = 'popup(\'' . $data->integratedURL . '$1\'';
-            $callback_header[] = '';
         }
 
         /**

--- a/components/com_jfusion/plugins/phpbb31/public.php
+++ b/components/com_jfusion/plugins/phpbb31/public.php
@@ -418,7 +418,8 @@ class JFusionPublic_phpbb31 extends JFusionPublic
             
             //convert relative links from images into absolute links
 
-            $regex_body[] = '#(src="|background="|url\(\'?)[\.\/].*?(.*?)("|\'?\))#mS';
+            $regex_body[] = '#(src="|background="|url\(\'?)[\.\/]*([^:]*?)(["\'\)]+)#mS';
+            
             $replace_body[] = '$1' . $data->integratedURL . '$2$3';
             $callback_function[] = '';
             //fix for form actions
@@ -720,7 +721,7 @@ class JFusionPublic_phpbb31 extends JFusionPublic
             $replace_header = array();
             $callback_header = array();
             //convert relative links into absolute links
-            $regex_header[] = '#(href="|src=")[\.\/].*?(.*?")#mS';
+            $regex_header[] = '#(href="|src=")[\.\/]+(.*?")#mS';
             $replace_header[] = '$1' . $data->integratedURL . '$2';
             $callback_header[] = '';
             //fix for URL redirects


### PR DESCRIPTION
I have tested these changes on my live site for over a month with no issues.

Remove popup code as phpBB3.1 no longer uses popup notifications and resolve issue with double slashes and invalid relative paths.  These issues become worse when using sh404sef extension. 

**First change line 412**: Three changes!
1.  Remove leading / to prevent double / between domain name and path, with sh404sef a  ../../../ relative path can be generated, this  needs removing, so strip out any slashes and dots at the start of the path [.\/]*
2.  To prevent modification of links to images for offsite avatars, etc. that include a domain name  the any character sequence (_.?) has been replaced with any character except colon ([^:]_?) 
3.   The match for end of path is now any sequence of at least one or singe quote, double quote or closing bracket (["\')]+)

**Second Change 428**: Remove popup code.

**Third change line 723**: 
1.  Modify paten to remove a leading slash or dot to remove multiple slashes and dots [.\/]+ sh404sef was generating a ../../ sequence.

**Fourth change 730**: Remove popup code.

I hope this explains the changes.
