### PR TITLE
jfusion_phpext_direct_access_groups to support users in multiple groups.

### DIFF
--- a/components/com_jfusion/plugins/phpbb31/jfusion/phpbbext/config/services.yml
+++ b/components/com_jfusion/plugins/phpbb31/jfusion/phpbbext/config/services.yml
@@ -12,6 +12,9 @@ services:
         arguments:
             - @config
             - @user
+            - %core.root_path%
+            - %core.php_ext%
+                        
         tags:
             - { name: event.listener }
 


### PR DESCRIPTION
The jfusion_phpext_direct_access_groups dose not work if a user is a member of multiple groups.  This pull request solves this by fetching all the groups the user is a member of and comparing this to the direct access groups.  
